### PR TITLE
Add consistent_comment_rule option for CSS

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,9 +1,10 @@
 {
     "preserve_newlines": true,
+    "max_preserve_newlines": 10,
+	"consistent_comment_rule": true,
     "jslint_happy": true,
     "keep_array_indentation": true,
     "space_before_conditional": true,
-    "max_preserve_newlines": 10,
     "brace_style": "collapse",
     "keep_function_indentation": false,
     "break_chained_methods": false,

--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,7 @@
 {
     "preserve_newlines": true,
     "max_preserve_newlines": 10,
-	"consistent_comment_rule": true,
+    "consistent_comment_rule": true,
     "jslint_happy": true,
     "keep_array_indentation": true,
     "space_before_conditional": true,


### PR DESCRIPTION
In beautify-css.js, consistent_comment_rule option is false by default. This settings.json shall set it to true.
